### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "moment": "^2.24.0",
     "multer": "^1.4.1",
     "nodemon": "^1.18.10",
-    "npm": "^6.9.0",
     "passport": "^0.4.0",
     "passport-local": "^1.0.0",
     "pg": "^7.9.0",


### PR DESCRIPTION

Hello marinadell!

It seems like you have npm as one of your (dev-) dependency in sole-check.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
